### PR TITLE
Rust optimizations, use bytes and i32

### DIFF
--- a/rust/src/levenshtein_distance.rs
+++ b/rust/src/levenshtein_distance.rs
@@ -7,12 +7,12 @@ pub fn levenshtein_distance(source: &str, target: &str) -> usize {
         return source.len();
     }
 
-    let mut cache: Vec<usize> = (0..=target.chars().count()).collect();
+    let mut cache: Vec<i32> = (0..=target.len() as i32).collect();
 
-    for (i, source_char) in source.chars().enumerate() {
-        let mut next_dist = i + 1;
+    for (i, source_char) in source.bytes().enumerate() {
+        let mut next_dist = (i as i32) + 1;
 
-        for (j, target_char) in target.chars().enumerate() {
+        for (j, target_char) in target.bytes().enumerate() {
             let current_dist = next_dist;
 
             let mut dist_if_substitute = cache[j];
@@ -23,10 +23,7 @@ pub fn levenshtein_distance(source: &str, target: &str) -> usize {
             let dist_if_insert = current_dist + 1;
             let dist_if_delete = cache[j + 1] + 1;
 
-            next_dist = min(
-                dist_if_delete,
-                min(dist_if_insert, dist_if_substitute),
-            );
+            next_dist = min(dist_if_delete, min(dist_if_insert, dist_if_substitute));
 
             cache[j] = current_dist;
         }
@@ -34,9 +31,13 @@ pub fn levenshtein_distance(source: &str, target: &str) -> usize {
         cache[target.len()] = next_dist;
     }
 
-    cache[target.len()]
+    cache[target.len()] as usize
 }
 
-fn min(a: usize, b: usize) -> usize {
-    if a < b { a } else { b }
+fn min(a: i32, b: i32) -> i32 {
+    if a < b {
+        a
+    } else {
+        b
+    }
 }


### PR DESCRIPTION
```
$ node run.js bench
go: 1.413010
javascript: 2.992
rust: 1.051997763
```

This might not be in the spirit of the exercise as working on bytes not chars. 