### PR TITLE
rust: amortize allocations

### DIFF
--- a/rust/src/levenshtein_distance.rs
+++ b/rust/src/levenshtein_distance.rs
@@ -1,40 +1,53 @@
-pub fn levenshtein_distance(source: &str, target: &str) -> usize {
-    if source.is_empty() {
-        return target.len();
-    }
+#[derive(Debug, Default)]
+pub struct LevenshteinDistance {
+    source: Vec<char>,
+    target: Vec<char>,
+    cache: Vec<usize>,
+}
 
-    if target.is_empty() {
-        return source.len();
-    }
-
-    let mut cache: Vec<usize> = (0..=target.chars().count()).collect();
-
-    for (i, source_char) in source.chars().enumerate() {
-        let mut next_dist = i + 1;
-
-        for (j, target_char) in target.chars().enumerate() {
-            let current_dist = next_dist;
-
-            let mut dist_if_substitute = cache[j];
-            if source_char != target_char {
-                dist_if_substitute += 1;
-            }
-
-            let dist_if_insert = current_dist + 1;
-            let dist_if_delete = cache[j + 1] + 1;
-
-            next_dist = min(
-                dist_if_delete,
-                min(dist_if_insert, dist_if_substitute),
-            );
-
-            cache[j] = current_dist;
+impl LevenshteinDistance {
+    pub fn distance(&mut self, source: &str, target: &str) -> usize {
+        if source.is_empty() {
+            return target.len();
+        }
+        if target.is_empty() {
+            return source.len();
         }
 
-        cache[target.len()] = next_dist;
-    }
+        self.source.clear();
+        self.source.extend(source.chars());
+        self.target.clear();
+        self.target.extend(target.chars());
+        self.cache.clear();
+        self.cache.extend(0..=self.target.len());
 
-    cache[target.len()]
+        for (i, source_char) in self.source.iter().enumerate() {
+            let mut next_dist = i + 1;
+
+            for (j, target_char) in self.target.iter().enumerate() {
+                let current_dist = next_dist;
+
+                let mut dist_if_substitute = self.cache[j];
+                if source_char != target_char {
+                    dist_if_substitute += 1;
+                }
+
+                let dist_if_insert = current_dist + 1;
+                let dist_if_delete = self.cache[j + 1] + 1;
+
+                next_dist = min(
+                    dist_if_delete,
+                    min(dist_if_insert, dist_if_substitute),
+                );
+
+                self.cache[j] = current_dist;
+            }
+
+            self.cache[target.len()] = next_dist;
+        }
+
+        self.cache[target.len()]
+    }
 }
 
 fn min(a: usize, b: usize) -> usize {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,15 +1,16 @@
 mod levenshtein_distance;
 
-use levenshtein_distance::levenshtein_distance;
+use levenshtein_distance::LevenshteinDistance;
 
 fn main() {
     let lines: Vec<&str> = include_str!("../../sample.txt").split('\n').collect();
 
     let benchmark = || {
+        let mut levenshtein = LevenshteinDistance::default();
         for _ in 0..10000 {
             let mut last_value = "";
             for line in &lines {
-                levenshtein_distance(last_value, line);
+                levenshtein.distance(last_value, line);
                 last_value = line;
             }
         }
@@ -28,7 +29,7 @@ fn main() {
 
     // check
     let answers: Vec<String> = (0..lines.len()-1)
-        .map(|i| levenshtein_distance(lines[i], lines[i+1]))
+        .map(|i| LevenshteinDistance::default().distance(lines[i], lines[i+1]))
         .map(|dist| dist.to_string())
         .collect();
     eprintln!("{}", answers.join(","));


### PR DESCRIPTION
This is a PoC for only the Rust code that shows how to optimize it a bit
more by both amortizing allocation and reusing the result of UTF-8
decoding instead of repeating it for each iteration of the inner loop.

The results on my machine:

    $ yarn bench
    yarn run v1.22.4
    $ node run.js bench
    go: 1.573124
    javascript: 2.94
    rust: 1.295147587
    Done in 6.17s.

Of course, this isn't a fair comparison, since this doesn't update the
Go code to reuse allocation either. Although it wouldn't be surprising
if its GC was doing this automatically anyway.

I'm not necessarily submitting this with a request to merge it, but
rather, just providing more data.