### PR TITLE
Remove unnecessary mut from variable

### DIFF
--- a/rust/src/levenshtein_distance.rs
+++ b/rust/src/levenshtein_distance.rs
@@ -15,10 +15,13 @@ pub fn levenshtein_distance(source: &str, target: &str) -> usize {
         for (j, target_char) in target.chars().enumerate() {
             let current_dist = next_dist;
 
-            let mut dist_if_substitute = cache[j];
-            if source_char != target_char {
-                dist_if_substitute += 1;
-            }
+            let dist_if_substitute = {
+                if source_char == target_char {
+                    cache[j]
+                } else {
+                    cache[j] + 1
+                }
+            };
 
             let dist_if_insert = current_dist + 1;
             let dist_if_delete = cache[j + 1] + 1;


### PR DESCRIPTION
Just removing an unnecessary `mut` from the `dist_if_substitute` variable, as it's common to avoid mut in rust where possible. This has a surprisingly large effect on performance:

before:
```
go: 1.768400
javascript: 3.54
rust: 2.069717745
```

after:
```
go: 1.757984
javascript: 3.347
rust: 1.415786823
```

Both tests were run on a Dell XPS.